### PR TITLE
ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+    "parser": "babel-eslint",
+    "env": {
+        "browser": true,
+        "es6": true,
+        "node": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended"
+    ],
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "react"
+    ],
+    "rules": {
+    }
+};

--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-.eslintrc.js


### PR DESCRIPTION
Removed `.eslintrc.js` from `.gitignore` so that ESLint configs are shared.